### PR TITLE
HA-140 - Adaptive lighting tweaks

### DIFF
--- a/blueprints/smart_adaptive_lighting_scene_activator.yaml
+++ b/blueprints/smart_adaptive_lighting_scene_activator.yaml
@@ -577,6 +577,11 @@ action:
       - alias: action is in mqtt_off_actions
         conditions: "{{ action in mqtt_off_actions_list }}"
         sequence:
+          - action: adaptive_lighting.set_manual_control
+            data:
+              manual_control: true
+              lights:
+                "{{ primary_lights.entity_id }}"
           - action: switch.turn_off
             target:
               "{{ primary_lights_adaptive_lighting_switches }}"

--- a/blueprints/smart_adaptive_lighting_scene_activator.yaml
+++ b/blueprints/smart_adaptive_lighting_scene_activator.yaml
@@ -270,12 +270,10 @@ blueprint:
             Default:
 
             ```
-            Morning
             Bedtime
             Night
             ```
           default: |
-            Morning
             Bedtime
             Night
           selector:

--- a/blueprints/smart_adaptive_lighting_scene_activator.yaml
+++ b/blueprints/smart_adaptive_lighting_scene_activator.yaml
@@ -566,6 +566,9 @@ action:
                 action: adaptive_lighting.apply
                 data:
                   entity_id: "{{ primary_lights_adaptive_lighting_switches.entity_id }}"
+                  adapt_brightness: true
+                  adapt_color: true
+                  prefer_rgb_color: "{{ enable_rgb_color }}"
                   turn_on_lights: true
               - action: switch.turn_off
                 target:
@@ -678,6 +681,9 @@ action:
                     action: adaptive_lighting.apply
                     data:
                       entity_id: "{{ secondary_lights_adaptive_lighting_switches.entity_id }}"
+                      adapt_brightness: true
+                      adapt_color: true
+                      prefer_rgb_color: "{{ enable_rgb_color }}"
                       turn_on_lights: true
                   - action: switch.turn_off
                     target:
@@ -720,11 +726,15 @@ action:
         sequence:
           - action: adaptive_lighting.change_switch_settings
             data:
-              # only sets primary color. This is desired _except_ where secondary lighys are truly secondary (e.g., Guest Ceiling fan)
-              # I think an additional input will be necessary to make the distinction
-              # `secondary_switch_follows_primary_switch_settings`
               use_defaults: configuration
               entity_id: "{{ primary_lights_adaptive_lighting_switches.entity_id }}"
+              prefer_rgb_color: "{{ enable_rgb_color }}"
+          - action: adaptive_lighting.change_switch_settings
+            data:
+              # this will set color mode for secondary lights, but is redundant if secondary lights have
+              # their own SALSA automation.
+              use_defaults: configuration
+              entity_id: "{{ secondary_lights_adaptive_lighting_switches.entity_id }}"
               prefer_rgb_color: "{{ enable_rgb_color }}"
           - choose:
               - conditions: "{{ enable_sleep == true }}"

--- a/blueprints/smart_adaptive_lighting_scene_activator.yaml
+++ b/blueprints/smart_adaptive_lighting_scene_activator.yaml
@@ -734,13 +734,17 @@ action:
               use_defaults: configuration
               entity_id: "{{ primary_lights_adaptive_lighting_switches.entity_id }}"
               prefer_rgb_color: "{{ enable_rgb_color }}"
-          - action: adaptive_lighting.change_switch_settings
-            data:
+          - if: 
+              - condition: template
+                value_template: "{{ secondary_lights.entity_id is defined and (secondary_lights | length > 0) }}"
+            then:
               # this will set color mode for secondary lights, but is redundant if secondary lights have
               # their own SALSA automation.
-              use_defaults: configuration
-              entity_id: "{{ secondary_lights_adaptive_lighting_switches.entity_id }}"
-              prefer_rgb_color: "{{ enable_rgb_color }}"
+              - action: adaptive_lighting.change_switch_settings
+                data:
+                  use_defaults: configuration
+                  entity_id: "{{ secondary_lights_adaptive_lighting_switches.entity_id }}"
+                  prefer_rgb_color: "{{ enable_rgb_color }}"
           - choose:
               - conditions: "{{ enable_sleep == true }}"
                 sequence:

--- a/blueprints/smart_adaptive_lighting_scene_activator.yaml
+++ b/blueprints/smart_adaptive_lighting_scene_activator.yaml
@@ -500,11 +500,13 @@ variables:
   sleep_mode_additional_lights: !input sleep_mode_additional_lights
   # TODO: `sleep_mode_switches` should be updated to use the adaptive_lighting switch entities instead of lights to generate sleep switch list
   sleep_mode_switches: >
-    {%- set data = namespace(switches=) %}
-    {%- set lights_list = primary_lights.entity_id if primary_lights.entity_id is sequence else [primary_lights.entity_id] %}
-    {%- for light in lights_list + sleep_mode_additional_lights %} 
-      {%- set data.switches = data.switches + ['switch.adaptive_lighting_sleep_mode_' + light.replace('light.','')] %}
-    {%- endfor %}
+    {%- set data = namespace(switches=[]) %}
+    {%- set lights_list = [primary_lights.entity_id] if primary_lights.entity_id is sequence else [primary_lights.entity_id] %}
+    {%- if  sleep_mode_additional_lights is defined %}
+      {%- for light in lights_list + sleep_mode_additional_lights %}
+        {%- set data.switches = data.switches + ['switch.adaptive_lighting_sleep_mode_' + light.replace('light.','')] %}
+      {%- endfor %}
+    {%- endif %}
     {{ data.switches }}
   current_mode: >
     {%- set current_mode = '' %}


### PR DESCRIPTION
PR includes the following:

- Fix `sleep_mode_switches` code
- Apply desired switch configuration every time `adaptive_lighting.apply` is called
- Apply manual mode via `adaptive_lighting.set_manual_control` when primary lights turned off to try and avoid lights turning back on
- Apply rgb color mode to secondary lights, if specified
- Remove `Morning` from `color_phases` default